### PR TITLE
Evaluate if condition in pass 1, even in local scope. & Support (IX-d) 

### DIFF
--- a/packages/z80-asm/src/Asm.spec.ts
+++ b/packages/z80-asm/src/Asm.spec.ts
@@ -130,6 +130,13 @@ describe("assemble", () => {
             { line: " jp $", opcodes: [0xC3, 0x00, 0x40] },
         ]);
     });
+
+    it("ix minus offset", ()=>{
+        runTest([
+            {line :"ld (ix-3),a", opcodes:[0xdd, 0x77, 0xfd] }
+        ]);
+    });
+
 });
 
 describe("number parsing", () => {

--- a/packages/z80-asm/src/Asm.ts
+++ b/packages/z80-asm/src/Asm.ts
@@ -1465,7 +1465,7 @@ class LineParser {
                 const args = new Map<OpcodeTemplateOperand, number>();
 
                 match = true;
-
+                let sgn=1;
                 for (let i = 0; i < variant.tokens.length; i++) {
                     const token = variant.tokens[i];
 
@@ -1484,9 +1484,20 @@ class LineParser {
                         continue;
                     }
 
-                    if (token === "," || token === "(" || token === ")" || token === "+") {
+                    if (token === "," || token === "(" || token === ")") {
                         if (!this.foundChar(token)) {
                             match = false;
+                        }
+                    } else if (token === "+" ) {
+                        // For LD A,(IX-dd)
+                        if (!this.foundChar(token)) {
+                            if (this.foundChar("-")) {
+                                sgn=-1;
+                            } else {
+                                match = false;
+                            }
+                        } else {
+                            sgn=1;
                         }
                     } else if (isOpcodeTemplateOperand(token)) {
                         // Parse.
@@ -1498,7 +1509,8 @@ class LineParser {
                             if (args.has(token)) {
                                 throw new Error("duplicate arg: " + this.line);
                             }
-                            args.set(token, value);
+                            args.set(token, value*sgn);
+                            sgn=1;
                         }
                     } else if (parseDigit(token[0], 10) !== undefined) {
                         // If the token is a number, then we must parse an expression and

--- a/packages/z80-asm/src/Asm.ts
+++ b/packages/z80-asm/src/Asm.ts
@@ -1906,10 +1906,13 @@ class LineParser {
             let symbolInfo = this.pass.locals().get(identifier, this.pass.passNumber !== 1);
             if (symbolInfo === undefined) {
                 if (this.pass.passNumber === 1) {
+                    // For if directive, defined value is needed;
+                    const definedSymbolInfo = this.pass.locals().get(identifier, true);
+                    const value=definedSymbolInfo ? definedSymbolInfo.value : 0;
                     // Record that this identifier was used so that we can include its file with
                     // library includes. We don't know whether it's a local or global symbol.
                     // Assume local and push it out in #endlocal.
-                    symbolInfo = new SymbolInfo(identifier, 0);
+                    symbolInfo = new SymbolInfo(identifier, value);
                     this.pass.locals().set(symbolInfo);
                 } else {
                     throw new Error("Identifier " + identifier + " was not defined in pass 1");


### PR DESCRIPTION
Previous version evaluates `x ne y` as `false` bacause all outer variables of local scope are evaluated as `0` in pass 1
```
x equ 1
y equ 2
#local
 if x ne y
    ld a,0
 endif
#endlocal
```
